### PR TITLE
Fix encoded component path on repository links

### DIFF
--- a/src/commands/connect/plugin.ts
+++ b/src/commands/connect/plugin.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import path from "path";
 import dedent from "ts-dedent";
 import urljoin from "url-join";
 import { ComponentConfigFile, ConnectPluginInstance, Plugin, GitConfig } from "./interfaces/config";
@@ -103,13 +104,15 @@ const createRepoLink = (
     const url = gitConfig.url || repoDefaults.url;
     const { repository } = gitConfig;
     const branch = gitConfig.branch || repoDefaults.branch;
-    const path = encodeURIComponent(gitConfig.path || "");
-    const encodedPath = encodeURIComponent(componentPath);
+    const basePath = gitConfig.path || "";
     const prefix = repoDefaults.prefix || "";
+    const filePath = componentPath.split(path.sep);
 
     return {
         type: repoDefaults.type,
-        url: urljoin(url, repository, prefix, branch, path, encodedPath)
+        url: encodeURI(
+            urljoin(url, repository, prefix, branch, basePath, ...filePath)
+        )
     };
 };
 


### PR DESCRIPTION
Fixed an issue with repository links where file separator characters in the component path are percent-encoded. Also fixed another possible issue where the link could be generated using Windows file separators

old
`https://github.com/yuqu/wow-much-repository/blob/master/src%2Fcomponents%2FButton%2FButton.js`

current
`https://github.com/yuqu/wow-much-repository/blob/master/src/components/Button/Button.js`