### PR TITLE
Fix running login command when there is no existing token

### DIFF
--- a/src/commands/login/login.ts
+++ b/src/commands/login/login.ts
@@ -6,7 +6,7 @@ import logger from "../../util/logger";
 
 import * as envUtil from "../../util/env";
 import * as authFileUtil from "../../util/auth-file";
-import { AuthenticationService, AUTH_METHOD } from "../../service/index";
+import { AuthenticationService, AUTH_METHOD } from "../../service";
 
 export interface LoginOptions {
     noBrowser: boolean;
@@ -30,19 +30,23 @@ export async function login(options: LoginOptions): Promise<void> {
             if (answer.choice !== "y") {
                 return;
             }
-
-            const authService = new AuthenticationService({
-                token: existingToken,
-                method: AUTH_METHOD.LOCAL_AUTH_FILE
-            });
-
-            await authService.promptForLogin({
-                ignoreSaveTokenErrors: false,
-                noBrowser: options.noBrowser,
-                forceRenewal: true
-            });
-
-            logger.info(chalk.bold("\n🦄 Successfully authenticated."));
         }
+
+        const authService = new AuthenticationService(
+            existingToken
+                ? {
+                    token: existingToken,
+                    method: AUTH_METHOD.LOCAL_AUTH_FILE
+                }
+                : undefined
+        );
+
+        await authService.promptForLogin({
+            ignoreSaveTokenErrors: false,
+            noBrowser: options.noBrowser,
+            forceRenewal: true
+        });
+
+        logger.info(chalk.bold("\n🦄 Successfully authenticated."));
     }
 }


### PR DESCRIPTION
## Change description

Previously, cli did nothing when there is no stored token. With this PR, cli prompts for login for both cases.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
