### PR TITLE
feat: Add `force` flag for connect requests

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -87,7 +87,8 @@ export class ZeplinApi {
     async uploadConnectedComponents(
         authToken: string,
         params: { barrelId: string; barrelType: BarrelType },
-        body: ConnectedComponents
+        body: ConnectedComponents,
+        queryParams: { forceOverwrite: boolean }
     ): Promise<void> {
         try {
             const { barrelId, barrelType } = params;
@@ -96,7 +97,8 @@ export class ZeplinApi {
                 `/public/cli/v2/${barrelType}/${barrelId}/connectedcomponents`,
                 body,
                 {
-                    headers: { "Zeplin-Access-Token": authToken }
+                    headers: { "Zeplin-Access-Token": authToken },
+                    params: queryParams
                 }
             );
         } catch (error) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,7 +10,7 @@ import {
     StyleguideResponse
 } from "./interfaces";
 import { APIError, CLIError } from "../errors";
-import { ConnectedComponentList } from "../commands/connect/interfaces/api";
+import { ConnectedComponents } from "../commands/connect/interfaces/api";
 import { MOVED_TEMPORARILY } from "http-status-codes";
 import { URLSearchParams } from "url";
 
@@ -87,13 +87,13 @@ export class ZeplinApi {
     async uploadConnectedComponents(
         authToken: string,
         params: { barrelId: string; barrelType: BarrelType },
-        body: ConnectedComponentList
+        body: ConnectedComponents
     ): Promise<void> {
         try {
             const { barrelId, barrelType } = params;
 
             await this.axios.put(
-                `/public/cli/${barrelType}/${barrelId}/connectedcomponents`,
+                `/public/cli/v2/${barrelType}/${barrelId}/connectedcomponents`,
                 body,
                 {
                     headers: { "Zeplin-Access-Token": authToken }
@@ -115,7 +115,7 @@ export class ZeplinApi {
             const { barrelId, barrelType } = params;
 
             await this.axios.delete(
-                `/public/cli/${barrelType}/${barrelId}/connectedcomponents`,
+                `/public/cli/v2/${barrelType}/${barrelId}/connectedcomponents`,
                 {
                     headers: { "Zeplin-Access-Token": authToken }
                 }

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -31,7 +31,13 @@ const maskUrl = (_url: string | undefined): string | undefined => {
 };
 
 const requestLogger = (request: AxiosRequestConfig): AxiosRequestConfig => {
-    const { url, method, data, headers } = request;
+    const {
+        url,
+        method,
+        data,
+        headers,
+        params
+    } = request;
     let httpLog = `HTTP Request: ${method} ${maskUrl(url)}`;
 
     if (headers) {
@@ -39,6 +45,9 @@ const requestLogger = (request: AxiosRequestConfig): AxiosRequestConfig => {
     }
     if (data) {
         httpLog = httpLog.concat(`, Body: ${JSON.stringify(mask(data))}`);
+    }
+    if (params) {
+        httpLog = httpLog.concat(`, Params: ${JSON.stringify(mask(params))}`);
     }
 
     logger.http(httpLog);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,13 +53,15 @@ const connectCommand = program.command("connect")
     .option("-d, --dev", "Activate development mode", defaults.commands.connect.devMode)
     .option("--no-watch", "Disable watch files on development mode", defaults.commands.connect.devModeWatch)
     .option("-p, --plugin <plugin>", "npm package name of a Zeplin CLI connect plugin", createCollector(), [])
+    .option("-f, --force", "Forces overwriting possible changes from Zeplin apps", false)
     .action(commandRunner(async options => {
         const connectOptions: ConnectOptions = {
             configFiles: options.file,
             devMode: options.dev,
             devModePort: defaults.commands.connect.port,
             devModeWatch: options.watch,
-            plugins: options.plugin
+            plugins: options.plugin,
+            force: options.force
         };
 
         await connect(connectOptions);
@@ -86,6 +88,7 @@ connectCommand.command("initialize")
     .option("--file <configFile>", "Optional file path to create configuration", defaults.commands.initialize.filePath)
     .option("--skip-connect", "Skip connecting after configuration is created", false)
     .option("--skip-install", "Skip installation of packages during installation", false)
+    .option("-f, --force", "Forces overwriting possible changes from Zeplin apps", false)
     .action(commandRunner(async options => {
         const opts: InitializeCommandOptions = {
             configFile: options.file,
@@ -95,7 +98,8 @@ connectCommand.command("initialize")
             componentFilename: options.componentFilename,
             skipConnect: options.skipConnect,
             skipInstall: options.skipInstall,
-            type: options.type
+            type: options.type,
+            force: options.force
         };
         await initialize(opts);
     }));
@@ -108,6 +112,7 @@ connectCommand.command("add-components")
     .option("--filename <filename>", "Initializes configuration for this component file")
     .option("--file <configFile>", "Optional file path to create configuration", defaults.commands.initialize.filePath)
     .option("--skip-connect", "Skip connecting after configuration is created", false)
+    .option("-f, --force", "Forces overwriting possible changes from Zeplin apps", false)
     .action(commandRunner(async options => {
         const opts: AddComponentCommandOptions = {
             configFile: options.file,
@@ -115,7 +120,8 @@ connectCommand.command("add-components")
             projectId: options.projectId,
             styleguideId: options.styleguideId,
             componentFilename: options.filename,
-            skipConnect: options.skipConnect
+            skipConnect: options.skipConnect,
+            force: options.force
         };
         await addComponent(opts);
     }));

--- a/src/commands/connect/connect.ts
+++ b/src/commands/connect/connect.ts
@@ -12,7 +12,8 @@ import { ConnectedComponentsService } from "./service";
 
 const getComponentFilePaths = (connectedBarrels: ConnectedBarrelComponents[]): string[] =>
     connectedBarrels.map(f =>
-        f.connectedComponents.map(c => path.resolve(c.path))
+        f.items.map(c => (c.filePath ? path.resolve(c.filePath) : undefined))
+            .filter((value): value is string => value !== undefined)
     ).reduce((a, b) => [...a, ...b], []);
 
 const generateConnectedComponents = async (

--- a/src/commands/connect/connect.ts
+++ b/src/commands/connect/connect.ts
@@ -89,10 +89,10 @@ const startDevServer = async (
 
 const service = new ConnectedComponentsService();
 
-const upload = async (connectedBarrels: ConnectedBarrelComponents[]): Promise<void> => {
+const upload = async (connectedBarrels: ConnectedBarrelComponents[], { force }: ConnectOptions): Promise<void> => {
     logger.info("Connecting all Connected Components into Zeplin…");
 
-    await service.uploadConnectedBarrels(connectedBarrels);
+    await service.uploadConnectedBarrels(connectedBarrels, { force });
 
     logger.info("🦄 Components successfully connected to components in Zeplin.");
 };
@@ -106,7 +106,7 @@ async function connect(options: ConnectOptions): Promise<void> {
         if (options.devMode) {
             await startDevServer(options, connectedBarrels);
         } else {
-            await upload(connectedBarrels);
+            await upload(connectedBarrels, options);
         }
     } catch (error) {
         error.message = dedent`
@@ -124,6 +124,7 @@ export interface ConnectOptions {
     devModePort: number;
     devModeWatch: boolean;
     plugins: string[];
+    force: boolean;
 }
 
 export {

--- a/src/commands/connect/connect.ts
+++ b/src/commands/connect/connect.ts
@@ -9,12 +9,16 @@ import { ConnectedBarrelComponents } from "./interfaces/api";
 import { connectComponentConfigFiles } from "./plugin";
 import { ConnectDevServer } from "./server";
 import { ConnectedComponentsService } from "./service";
+import { isDefined } from "../../util/object";
+import { flat } from "../../util/array";
 
-const getComponentFilePaths = (connectedBarrels: ConnectedBarrelComponents[]): string[] =>
-    connectedBarrels.map(f =>
-        f.items.map(c => (c.filePath ? path.resolve(c.filePath) : undefined))
-            .filter((value): value is string => value !== undefined)
-    ).reduce((a, b) => [...a, ...b], []);
+const getComponentFilePaths = (connectedBarrels: ConnectedBarrelComponents[]): string[] => (
+    flat(
+        connectedBarrels.map(f =>
+            f.items.map(c => (c.filePath ? path.resolve(c.filePath) : undefined)).filter(isDefined)
+        )
+    )
+);
 
 const generateConnectedComponents = async (
     options: Partial<Pick<ConnectOptions, "configFiles" | "plugins">>

--- a/src/commands/connect/interfaces/api.d.ts
+++ b/src/commands/connect/interfaces/api.d.ts
@@ -1,33 +1,30 @@
 import { Link } from "./plugin";
 
 /** @internal */
-export interface Data {
-    plugin: string;
-    lang?: string;
-    description?: string;
-    snippet?: string;
-}
+export type ConnectedComponentItem = (
+    ({ componentId: string } | { pattern: string })
+    & {
+        name?: string;
+        description?: string;
+        filePath?: string;
+        code?: {
+            snippet: string;
+            lang?: string;
+        };
+        links?: Link[];
+    }
+);
 
 /** @internal */
-export interface ConnectedComponent {
-    path: string;
-    zeplinNames?: string[];
-    zeplinIds?: string[];
-    name?: string;
-    urlPaths?: Link[];
-    data?: Data[];
-}
-
-/** @internal */
-export interface ConnectedComponentList {
-    connectedComponents: ConnectedComponent[];
+export interface ConnectedComponents {
+    items: ConnectedComponentItem[];
 }
 
 /** @internal */
 export interface ConnectedBarrelComponents {
     projects: string[];
     styleguides: string[];
-    connectedComponents: ConnectedComponent[];
+    items: ConnectedComponentItem[];
 }
 
 /** @internal */

--- a/src/commands/connect/plugin.ts
+++ b/src/commands/connect/plugin.ts
@@ -280,7 +280,7 @@ const connectComponentConfig = async (
 ): Promise<ConnectedComponentItem[]> => {
     // Execute all plugins
     const pluginResponses = (await Promise.all(plugins.map(plugin => processPlugin(plugin, component))))
-        .filter((item): item is ProcessResponse => item !== undefined);
+        .filter(isDefined);
 
     const links: Link[] = [
         ...createLinksFromConfigFile(component, componentConfigFile),

--- a/src/commands/connect/plugin.ts
+++ b/src/commands/connect/plugin.ts
@@ -15,6 +15,8 @@ import { defaults } from "../../config/defaults";
 import logger from "../../util/logger";
 import { isRunningFromGlobal } from "../../util/package";
 import { getInstallCommand } from "../../util/text";
+import { flat } from "../../util/array";
+import { isDefined } from "../../util/object";
 
 const ALLOWED_LINK_TYPES = [
     LinkType.styleguidist,
@@ -224,7 +226,7 @@ const createLinksFromConfigFile = (
         }
     }
     return undefined;
-}).filter((item): item is Link => item !== undefined);
+}).filter(isDefined);
 
 type ProcessResponse = {
     links: Link[];
@@ -302,11 +304,13 @@ const connectComponentConfig = async (
         codeAndDescriptions.push({});
     }
 
-    return codeAndDescriptions.map(codeAndDescription => componentConfigToConnectedComponentItems({
-        component,
-        links,
-        ...codeAndDescription
-    })).reduce((acc, curr) => acc.concat(curr), []);
+    return flat(
+        codeAndDescriptions.map(codeAndDescription => componentConfigToConnectedComponentItems({
+            component,
+            links,
+            ...codeAndDescription
+        }))
+    );
 };
 
 const connectComponentConfigFile = async (
@@ -316,7 +320,7 @@ const connectComponentConfigFile = async (
 
     const plugins = await initializePlugins(componentConfigFile.plugins || [], components);
 
-    const items = (await Promise.all(
+    const items = flat(await Promise.all(
         components.map(component =>
             connectComponentConfig(
                 component,
@@ -324,7 +328,7 @@ const connectComponentConfigFile = async (
                 plugins
             )
         )
-    )).reduce((acc, curr) => acc.concat(curr), []);
+    ));
 
     return {
         projects: componentConfigFile.projects || [],

--- a/src/commands/connect/server/connect-dev-server.ts
+++ b/src/commands/connect/server/connect-dev-server.ts
@@ -5,7 +5,7 @@ import { OK } from "http-status-codes";
 import { Socket } from "net";
 import { CLIError } from "../../../errors";
 import logger from "../../../util/logger";
-import { ConnectedBarrelComponents, ConnectedComponent } from "../interfaces/api";
+import { ConnectedBarrelComponents, ConnectedComponentItem } from "../interfaces/api";
 
 export class ConnectDevServer {
     connectedBarrels: ConnectedBarrelComponents[] = [];
@@ -17,12 +17,12 @@ export class ConnectDevServer {
         this.connectedBarrels = connectedBarrels;
     }
 
-    getConnectedComponents(barrelId: string): ConnectedComponent[] | null {
+    getConnectedComponents(barrelId: string): ConnectedComponentItem[] | null {
         const found = this.connectedBarrels.find(connectedBarrel =>
             connectedBarrel.projects.find(pid => pid === barrelId) ||
             connectedBarrel.styleguides.find(stid => stid === barrelId));
 
-        return found ? found.connectedComponents : null;
+        return found ? found.items : null;
     }
 
     updateConnectedBarrels(connectedBarrels: ConnectedBarrelComponents[]): void {

--- a/src/commands/connect/service.ts
+++ b/src/commands/connect/service.ts
@@ -80,7 +80,7 @@ export class ConnectedComponentsService {
                 await this.zeplinApi.uploadConnectedComponents(
                     authToken,
                     { barrelId: pid, barrelType: "projects" },
-                    { connectedComponents: connectedBarrelComponent.connectedComponents }
+                    { items: connectedBarrelComponent.items }
                 );
             }));
 
@@ -88,7 +88,7 @@ export class ConnectedComponentsService {
                 await this.zeplinApi.uploadConnectedComponents(
                     authToken,
                     { barrelId: stid, barrelType: "styleguides" },
-                    { connectedComponents: connectedBarrelComponent.connectedComponents }
+                    { items: connectedBarrelComponent.items }
                 );
             }));
         }));

--- a/src/tasks/connect-components.ts
+++ b/src/tasks/connect-components.ts
@@ -38,7 +38,7 @@ const connect: TaskStep<ConnectContext> = async (ctx): Promise<void> => {
             configFiles: [ctx.cliOptions.configFile]
         });
 
-        await ctx.connectService.uploadConnectedBarrels(connectedComponents);
+        await ctx.connectService.uploadConnectedBarrels(connectedComponents, { force: ctx.cliOptions.force });
     }
 };
 

--- a/src/tasks/context/connect.d.ts
+++ b/src/tasks/context/connect.d.ts
@@ -8,6 +8,7 @@ export type ConnectContext = AuthenticationContext
         cliOptions: {
             skipConnect: boolean;
             configFile: string;
+            force: boolean;
         };
         connectService: ConnectedComponentsService;
         skippedConnect: boolean;

--- a/src/tasks/context/initialize.d.ts
+++ b/src/tasks/context/initialize.d.ts
@@ -17,6 +17,7 @@ export interface CliOptions {
     configFile: string;
     skipConnect?: boolean;
     skipInstall?: boolean;
+    force: boolean;
 }
 
 export type InitializeContext = AuthenticationContext &

--- a/src/tasks/generate-config.ts
+++ b/src/tasks/generate-config.ts
@@ -8,6 +8,7 @@ import logger from "../util/logger";
 import { stringify } from "../util/text";
 import { SupportedProjectType } from "../service/project-type/project-types";
 import { PackageJson } from "../util/js/config";
+import { isDefined } from "../util/object";
 
 const writeFile = async (filePath: string, config: ComponentConfigFile): Promise<void> => {
     await mkdir(path.dirname(filePath));
@@ -30,7 +31,7 @@ const executeConfigurators = async (
             return null;
         })
     );
-    return pluginConfigs.filter(Boolean) as Array<{}>;
+    return pluginConfigs.filter(isDefined);
 };
 
 const getPluginConfigs = (

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -9,7 +9,10 @@ const asyncFilter = async <T, U>(arr: Array<T>, predicate: predicate<T, U>): Pro
 const sortByField = <T>(arr: Array<T>, key: keyof T): Array<T> =>
     arr.sort((a, b) => ((a[key] > b[key]) ? 1 : -1));
 
+const flat = <T>(arr: Array<Array<T>>): Array<T> => arr.reduce((acc, val) => acc.concat(val), []);
+
 export {
     asyncFilter,
-    sortByField
+    sortByField,
+    flat
 };

--- a/src/util/object.ts
+++ b/src/util/object.ts
@@ -5,3 +5,7 @@ export function sortByKeys<K extends string, V>(obj: Record<K, V>): Record<K, V>
         return output;
     }, {} as Record<K, V>);
 }
+
+export function isDefined<T>(value: T | undefined | null): value is NonNullable<T> {
+    return value !== undefined && value !== null;
+}

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -117,7 +117,7 @@ describe("ZeplinApi", () => {
             const { barrelType, barrelId } = samples.uploadParams;
 
             expect(Axios.put).toHaveBeenCalledWith(
-                `/public/cli/${barrelType}/${barrelId}/connectedcomponents`,
+                `/public/cli/v2/${barrelType}/${barrelId}/connectedcomponents`,
                 samples.connectedComponentList,
                 { headers: { "Zeplin-Access-Token": samples.validJwt } }
             );
@@ -139,7 +139,7 @@ describe("ZeplinApi", () => {
             const { barrelType, barrelId } = samples.uploadParams;
 
             expect(Axios.put).toHaveBeenCalledWith(
-                `/public/cli/${barrelType}/${barrelId}/connectedcomponents`,
+                `/public/cli/v2/${barrelType}/${barrelId}/connectedcomponents`,
                 samples.connectedComponentList,
                 { headers: { "Zeplin-Access-Token": samples.validJwt } }
             );
@@ -162,7 +162,7 @@ describe("ZeplinApi", () => {
             const { barrelType, barrelId } = samples.uploadParams;
 
             expect(Axios.put).toHaveBeenCalledWith(
-                `/public/cli/${barrelType}/${barrelId}/connectedcomponents`,
+                `/public/cli/v2/${barrelType}/${barrelId}/connectedcomponents`,
                 samples.connectedComponentList,
                 { headers: { "Zeplin-Access-Token": samples.validJwt } }
             );
@@ -181,7 +181,7 @@ describe("ZeplinApi", () => {
             const { barrelType, barrelId } = samples.deleteParams;
 
             expect(Axios.delete).toHaveBeenCalledWith(
-                `/public/cli/${barrelType}/${barrelId}/connectedcomponents`,
+                `/public/cli/v2/${barrelType}/${barrelId}/connectedcomponents`,
                 { headers: { "Zeplin-Access-Token": samples.validJwt } }
             );
         });
@@ -201,7 +201,7 @@ describe("ZeplinApi", () => {
             const { barrelType, barrelId } = samples.uploadParams;
 
             expect(Axios.delete).toHaveBeenCalledWith(
-                `/public/cli/${barrelType}/${barrelId}/connectedcomponents`,
+                `/public/cli/v2/${barrelType}/${barrelId}/connectedcomponents`,
                 { headers: { "Zeplin-Access-Token": samples.validJwt } }
             );
         });
@@ -222,7 +222,7 @@ describe("ZeplinApi", () => {
             const { barrelType, barrelId } = samples.deleteParams;
 
             expect(Axios.delete).toHaveBeenCalledWith(
-                `/public/cli/${barrelType}/${barrelId}/connectedcomponents`,
+                `/public/cli/v2/${barrelType}/${barrelId}/connectedcomponents`,
                 { headers: { "Zeplin-Access-Token": samples.validJwt } }
             );
         });

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -4,6 +4,7 @@ import { mocked } from "ts-jest/utils";
 import { ZeplinApi } from "../src/api";
 import { APIError, CLIError } from "../src/errors";
 
+// TODO: Use use nock instead of mocking Axios
 jest.mock("axios");
 
 describe("ZeplinApi", () => {
@@ -111,7 +112,8 @@ describe("ZeplinApi", () => {
             await zeplinApi.uploadConnectedComponents(
                 samples.validJwt,
                 samples.uploadParams,
-                samples.connectedComponentList
+                samples.connectedComponentList,
+                { forceOverwrite: false }
             );
 
             const { barrelType, barrelId } = samples.uploadParams;
@@ -119,7 +121,10 @@ describe("ZeplinApi", () => {
             expect(Axios.put).toHaveBeenCalledWith(
                 `/public/cli/v2/${barrelType}/${barrelId}/connectedcomponents`,
                 samples.connectedComponentList,
-                { headers: { "Zeplin-Access-Token": samples.validJwt } }
+                {
+                    headers: { "Zeplin-Access-Token": samples.validJwt },
+                    params: { forceOverwrite: false }
+                }
             );
         });
 
@@ -132,7 +137,8 @@ describe("ZeplinApi", () => {
                 zeplinApi.uploadConnectedComponents(
                     samples.validJwt,
                     samples.uploadParams,
-                    samples.connectedComponentList
+                    samples.connectedComponentList,
+                    { forceOverwrite: false }
                 )
             ).rejects.toThrowError(new APIError(samples.axiosError.response));
 
@@ -141,7 +147,10 @@ describe("ZeplinApi", () => {
             expect(Axios.put).toHaveBeenCalledWith(
                 `/public/cli/v2/${barrelType}/${barrelId}/connectedcomponents`,
                 samples.connectedComponentList,
-                { headers: { "Zeplin-Access-Token": samples.validJwt } }
+                {
+                    headers: { "Zeplin-Access-Token": samples.validJwt },
+                    params: { forceOverwrite: false }
+                }
             );
         });
 
@@ -155,7 +164,8 @@ describe("ZeplinApi", () => {
                 zeplinApi.uploadConnectedComponents(
                     samples.validJwt,
                     samples.uploadParams,
-                    samples.connectedComponentList
+                    samples.connectedComponentList,
+                    { forceOverwrite: false }
                 )
             ).rejects.toThrowError(new CLIError(errorMessage));
 
@@ -164,7 +174,10 @@ describe("ZeplinApi", () => {
             expect(Axios.put).toHaveBeenCalledWith(
                 `/public/cli/v2/${barrelType}/${barrelId}/connectedcomponents`,
                 samples.connectedComponentList,
-                { headers: { "Zeplin-Access-Token": samples.validJwt } }
+                {
+                    headers: { "Zeplin-Access-Token": samples.validJwt },
+                    params: { forceOverwrite: false }
+                }
             );
         });
     });

--- a/test/connect/service.test.ts
+++ b/test/connect/service.test.ts
@@ -28,7 +28,7 @@ describe("ConnectedComponentsService", () => {
                     method: AUTH_METHOD.ENVIRONMENT_VARIABLE
                 });
 
-                await service.uploadConnectedBarrels([sample]);
+                await service.uploadConnectedBarrels([sample], { force: false });
 
                 expect(service.authService.promptForLogin).toHaveBeenCalledTimes(1);
 
@@ -37,7 +37,8 @@ describe("ConnectedComponentsService", () => {
                         .toHaveBeenCalledWith(
                             samples.validJwt,
                             { barrelId, barrelType },
-                            { items: sample.items }
+                            { items: sample.items },
+                            { forceOverwrite: false }
                         );
                 };
 
@@ -64,7 +65,7 @@ describe("ConnectedComponentsService", () => {
                 });
                 mocked(service.zeplinApi.uploadConnectedComponents).mockRejectedValueOnce(authError);
 
-                await service.uploadConnectedBarrels([sample]);
+                await service.uploadConnectedBarrels([sample], { force: false });
 
                 expect(service.authService.promptForLogin).toHaveBeenCalledTimes(1);
 
@@ -73,7 +74,8 @@ describe("ConnectedComponentsService", () => {
                         .toHaveBeenCalledWith(
                             samples.validJwt,
                             { barrelId, barrelType },
-                            { items: sample.items }
+                            { items: sample.items },
+                            { forceOverwrite: false }
                         );
                 };
 
@@ -90,7 +92,7 @@ describe("ConnectedComponentsService", () => {
                 mocked(service.authService.authenticate).mockRejectedValueOnce(authError);
                 mocked(service.authService.promptForLogin).mockRejectedValueOnce(authError);
 
-                await expect(service.uploadConnectedBarrels([sample]))
+                await expect(service.uploadConnectedBarrels([sample], { force: false }))
                     .rejects
                     .toThrowError(authError);
 
@@ -106,7 +108,7 @@ describe("ConnectedComponentsService", () => {
 
                 mocked(service.authService.authenticate).mockRejectedValueOnce(error);
 
-                await expect(service.uploadConnectedBarrels([sample]))
+                await expect(service.uploadConnectedBarrels([sample], { force: false }))
                     .rejects
                     .toThrowError(error);
 
@@ -126,7 +128,7 @@ describe("ConnectedComponentsService", () => {
                 });
                 mocked(service.zeplinApi.uploadConnectedComponents).mockRejectedValueOnce(error);
 
-                await expect(service.uploadConnectedBarrels([sample]))
+                await expect(service.uploadConnectedBarrels([sample], { force: false }))
                     .rejects
                     .toThrowError(error);
 
@@ -143,7 +145,7 @@ describe("ConnectedComponentsService", () => {
                     method: AUTH_METHOD.ENVIRONMENT_VARIABLE
                 });
 
-                await service.uploadConnectedBarrels([sample]);
+                await service.uploadConnectedBarrels([sample], { force: false });
 
                 expect(service.authService.promptForLogin).not.toHaveBeenCalled();
 
@@ -152,7 +154,8 @@ describe("ConnectedComponentsService", () => {
                         .toHaveBeenCalledWith(
                             samples.validJwt,
                             { barrelId, barrelType },
-                            { items: sample.items }
+                            { items: sample.items },
+                            { forceOverwrite: false }
                         );
                 };
 
@@ -175,7 +178,7 @@ describe("ConnectedComponentsService", () => {
 
                     mocked(service.authService.authenticate).mockRejectedValueOnce(authError);
 
-                    await expect(service.uploadConnectedBarrels([sample]))
+                    await expect(service.uploadConnectedBarrels([sample], { force: false }))
                         .rejects
                         .toThrowError(authError);
 

--- a/test/connect/service.test.ts
+++ b/test/connect/service.test.ts
@@ -37,7 +37,7 @@ describe("ConnectedComponentsService", () => {
                         .toHaveBeenCalledWith(
                             samples.validJwt,
                             { barrelId, barrelType },
-                            { connectedComponents: sample.connectedComponents }
+                            { items: sample.items }
                         );
                 };
 
@@ -73,7 +73,7 @@ describe("ConnectedComponentsService", () => {
                         .toHaveBeenCalledWith(
                             samples.validJwt,
                             { barrelId, barrelType },
-                            { connectedComponents: sample.connectedComponents }
+                            { items: sample.items }
                         );
                 };
 
@@ -152,7 +152,7 @@ describe("ConnectedComponentsService", () => {
                         .toHaveBeenCalledWith(
                             samples.validJwt,
                             { barrelId, barrelType },
-                            { connectedComponents: sample.connectedComponents }
+                            { items: sample.items }
                         );
                 };
 

--- a/test/samples.ts
+++ b/test/samples.ts
@@ -1,4 +1,4 @@
-import { ConnectedBarrelComponents, ConnectedComponent, ConnectedComponentList } from "../src/commands/connect/interfaces/api";
+import { ConnectedBarrelComponents, ConnectedComponentItem, ConnectedComponents } from "../src/commands/connect/interfaces/api";
 import { LinkType } from "../src/commands/connect/interfaces/plugin";
 import { defaults } from "../src/config/defaults";
 import { BarrelType } from "../src/api";
@@ -24,34 +24,32 @@ export const invalidJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.invalid";
 export const validJwtWithoutAudience = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 export const validJwtWithoutDeleteScope = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiYXVkIjoidXNlcjoxMjMxMjMxMjMiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.p5Sr4rXPvVuNl9useetyAtYc7ZO6U73XmAhNUsFtFJs";
 
-export const connectedComponent1: ConnectedComponent = {
-    path: "src/Sample1.jsx",
-    zeplinNames: ["screen1"],
+export const connectedComponent1: ConnectedComponentItem = {
+    filePath: "src/Sample1.jsx",
+    pattern: "screen1",
     name: "Sample1",
-    data: [{
-        plugin: "pluginName",
-        lang: "jsx",
-        description: "desc",
-        snippet: "snip"
-    }],
-    urlPaths: [{
+    description: "desc",
+    code: {
+        snippet: "snip",
+        lang: "jsx"
+    },
+    links: [{
         type: LinkType.custom,
         url: "https://example.com",
         name: "urlName"
     }]
 };
 
-export const connectedComponent2: ConnectedComponent = {
-    path: "src/Sample2.jsx",
-    zeplinNames: ["screen2"],
+export const connectedComponent2: ConnectedComponentItem = {
+    filePath: "src/Sample2.jsx",
+    pattern: "screen2",
     name: "Sample2",
-    data: [{
-        plugin: "pluginName",
+    description: "desc",
+    code: {
         lang: "jsx",
-        description: "desc",
         snippet: "snip"
-    }],
-    urlPaths: [{
+    },
+    links: [{
         type: LinkType.custom,
         url: "https://example.com",
         name: "urlName"
@@ -61,14 +59,14 @@ export const connectedComponent2: ConnectedComponent = {
 export const connectedComponents: ConnectedBarrelComponents = {
     projects: ["pid1", "pid2"],
     styleguides: ["sid1", "sid2"],
-    connectedComponents: [
+    items: [
         connectedComponent1,
         connectedComponent2
     ]
 };
 
-export const connectedComponentList: ConnectedComponentList = {
-    connectedComponents: [
+export const connectedComponentList: ConnectedComponents = {
+    items: [
         connectedComponent1,
         connectedComponent2
     ]


### PR DESCRIPTION
## Change description

With [Zeplin Storybook integration](https://zpl.io/article/storybook-integration), users can update the connected component data from web and desktop apps. Using both CLI and web/desktop apps can be confusing for users. That's why we forbid updating the data from CLI if it's updated from web or desktop apps. To override this restriction, we also add `force` flag. So users can continue to use CLI even if they mistakenly update configuration from web or desktop apps.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
