### PR TITLE
fix: duplicate components if code key exists but is undefined

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
         - ./node_modules
     - run:
         name: Install npm packages
-        command: npm install
+        command: npm ci
     - run:
         name: Run linter
         command: npm run lint

--- a/src/commands/connect/plugin.ts
+++ b/src/commands/connect/plugin.ts
@@ -278,7 +278,8 @@ const connectComponentConfig = async (
     ];
 
     const codeAndDescriptions: CodeAndDescription[] = pluginResponses.reduce((acc, response) => {
-        if ("code" in response) {
+        if (("code" in response && response.code) ||
+            ("description" in response && response.description)) {
             return [...acc, { code: response.code, description: response.description }];
         }
         return acc;


### PR DESCRIPTION
## Change description

`pluginResponses` can have objects like the below sample, which causes duplicate connected components to show up on API request, hence on the Zeplin apps.

```
[
  {
    code: {
      snippet: '<Button\n' +
        '  primary={bool}\n' +
        '  backgroundColor={string}\n' +
        '  size={enum}\n' +
        '  label={string}\n' +
        '  onClick={func} />',
      lang: 'jsx'
    },
    description: 'Primary UI component for user interaction',
    links: []
  },
  {
    code: undefined,
    description: undefined,
    links: [ [Object], [Object], [Object], [Object] ]
  }
]
```

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
